### PR TITLE
ロケットに関するバグ修正

### DIFF
--- a/Rocket_Tag/Assets/Scripts/GameManager.cs
+++ b/Rocket_Tag/Assets/Scripts/GameManager.cs
@@ -111,6 +111,7 @@ public class GameManager : MonoBehaviourPunCallbacks
             ChooseRocketPlayer();
             StartCoroutine(eventManager.TriggerRandomEvent());
             StartCoroutine(CheckOverTime());
+            StartCoroutine(CheckRocketCnt());
         }
     }
 
@@ -175,6 +176,34 @@ public class GameManager : MonoBehaviourPunCallbacks
                 ChooseRocketPlayer();
             }
             yield return null;
+        }
+    }
+
+    IEnumerator CheckRocketCnt()
+    {
+        while (true)
+        {
+            List<GameObject> players = GetPlayerList();
+            int rocketCnt = 0;
+            for(int i = 0; i < players.Count; i++)
+            {
+                SetPlayerBool spb = players[i].GetComponent<SetPlayerBool>();
+                if(spb.hasRocket)
+                {
+                    rocketCnt++;
+                }
+            }
+
+            if(rocketCnt != 1)
+            {
+                for(int i = 0;i < players.Count;i++)
+                {
+                    PhotonView photon = players[i].GetComponent<PhotonView>();
+                    photon.RPC("SetHasRocket", RpcTarget.All, false);
+                }
+
+                ChooseRocketPlayer();
+            }
         }
     }
 


### PR DESCRIPTION
■対象のバグ
・ロケットが2つ以上存在する
・ロケットが1つも存在しない

■修正内容
上記の状態になったときに一度全員のロケットの所持状態をリセットしたあと、再配布するようにした